### PR TITLE
Backport Firefox selection fix

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -378,8 +378,11 @@ proto.setSelection = function ( range ) {
             this._win.focus();
         }
         var sel = this._sel;
-        sel.removeAllRanges();
-        sel.addRange( range );
+
+        if ( sel ) {
+          sel.removeAllRanges();
+          sel.addRange( range );
+        }
     }
     return this;
 };
@@ -394,7 +397,7 @@ proto.setSelectionToNode = function (node, startOffset){
 proto.getSelection = function () {
     var sel = this._sel,
         selection, startContainer, endContainer;
-    if ( sel.rangeCount ) {
+    if ( sel && sel.rangeCount ) {
         selection  = sel.getRangeAt( 0 ).cloneRange();
         startContainer = selection.startContainer;
         endContainer = selection.endContainer;

--- a/source/KeyHandlers.js
+++ b/source/KeyHandlers.js
@@ -410,14 +410,18 @@ var keyHandlers = {
 // it goes back/forward in history! Override to do the right
 // thing.
 // https://bugzilla.mozilla.org/show_bug.cgi?id=289384
-if ( isMac && isGecko && win.getSelection().modify ) {
-    keyHandlers[ 'meta-left' ] = function ( self, event ) {
-        event.preventDefault();
+if ( isMac && isGecko ) {
+      keyHandlers[ 'meta-left' ] = function ( self, event ) {
+      event.preventDefault();
+      if (self._sel && self._sel.modify) {
         self._sel.modify( 'move', 'backward', 'lineboundary' );
+      }
     };
     keyHandlers[ 'meta-right' ] = function ( self, event ) {
         event.preventDefault();
+      if (self._sel && self._sel.modify) {
         self._sel.modify( 'move', 'forward', 'lineboundary' );
+      }
     };
 }
 


### PR DESCRIPTION
Fix squire crashing when loaded on a offscreen iframe.

There may still be issues, we should probably take the time to sync back up with upstream, but fairly large effort I think.
