### PR TITLE
Whitelist a span class for reference links

### DIFF
--- a/source/Clean.js
+++ b/source/Clean.js
@@ -105,7 +105,8 @@ var filterSpanClasses = function(span){
         "ltx_cite": 1,
         "squire-citation": 1,
         "rendered": 1,
-        "raw": 1
+        "raw": 1,
+        "au-ref": 1,
     }
     return filterClasses(span, whiteList)
 }


### PR DESCRIPTION
No idea if I also need to version bump somewhere, but this should be all I need to do a `<span class="au-ref">` to hold reference links.