### PR TITLE
return result object instead of boolean in firstOrLastLine

### DIFF
--- a/source/CursorPosition.js
+++ b/source/CursorPosition.js
@@ -117,7 +117,7 @@ var firstOrLastLine = function(self){
     var nodeOffset = rect.top
     var parentOffset = parentBlock.getBoundingClientRect().top
     if(nodeOffset === parentOffset){
-      return true
+      return {firstLine: true, lastLine: true}
     }
     nodeOffset = nodeOffset - parentOffset
     lineHeight = window.getComputedStyle(parentBlock, null)["line-height"]


### PR DESCRIPTION
```isFirstLine``` and ```isLastLine``` functions expect a results object-literal, not a Boolean. 