### PR TITLE
Continuously watch and rebuild source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,3 +446,10 @@ Change the **inline** formatting of the current selection. This is a high-level 
 Takes in a function that can modify the document without the modifications being treated as input.
 
 This is useful when the document needs to be changed programmatically, but those changes should not raise input events or modify the undo state.
+
+
+### Development
+Watch source files for continuous rebuilding:
+
+```npm run build_dev
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Squire is an HTML5 rich text editor, which provides powerful cross-browser normalisation, whilst being supremely lightweight and flexible.",
   "main": "build/squire.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build_dev": "onchange ./source -- make"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
   "homepage": "https://github.com/neilj/Squire",
   "devDependencies": {
     "mocha": "2.2.5",
+    "onchange": "^3.2.1",
     "uglify-js": "^2.4.15",
     "unexpected": "8.2.0"
   }


### PR DESCRIPTION
A la 'webpack --watch'.

Could close https://github.com/natejenkins/squire/pull/55 as this essentially makes it redundant, though I s'pose we could leave it for extra insurance against pushing un-built changes. 