### PR TITLE
Sanitization for headers and divs (updated)

### DIFF
--- a/examples/test.js
+++ b/examples/test.js
@@ -72,7 +72,6 @@ var initEditors = function(){
     });
 
     testSetup()
-
     // quickTest()
     // NATE: unfortunately this test makes the later test "does not filter math elements" fail.  I don't yet understand why
     // but it has to do with how the cursor is positioned in the editor.
@@ -82,7 +81,7 @@ var initEditors = function(){
     testGetHTML()
     testInlineNodeNames()
     testCleaner()
-    testHeaderCleaner()
+    moreCleanerTests()
     // testLists()
     testTables()
     testInsertHTML()
@@ -531,7 +530,7 @@ testCleaner = function(){
 
 }
 
-testHeaderCleaner = function(){
+moreCleanerTests = function(){
   prepareTest("")
   s = '<h1><b>test</b> test</h1>'
   editor.setHTML(s)
@@ -568,6 +567,14 @@ testHeaderCleaner = function(){
   editor.setHTML(s)
   s2 = editor.getHTML()
   test(s2 == '<h2>test<br></h2>', 'strip nested div from header')
+
+  prepareTest("")
+  s = '<div><div><div>test</div></div></div>'
+  editor.setHTML(s)
+  s2 = editor.getHTML()
+  console.log('?????????XXXXX',s2)
+  test(s2 == '<div>test<br></div>', 'strip nested div')
+
 
 }
 

--- a/examples/test.js
+++ b/examples/test.js
@@ -82,6 +82,7 @@ var initEditors = function(){
     testGetHTML()
     testInlineNodeNames()
     testCleaner()
+    testHeaderCleaner()
     // testLists()
     testTables()
     testInsertHTML()
@@ -527,6 +528,46 @@ testCleaner = function(){
   s = "<div>a </div>"
   prepareTest(s)
   test(editor.getHTML({stripAllBrs: 1}) === s)
+
+}
+
+testHeaderCleaner = function(){
+  prepareTest("")
+  s = '<h1><b>test</b> test</h1>'
+  editor.setHTML(s)
+  s2 = editor.getHTML()
+  test(s2 == '<h1>test test<br></h1>', 'strip bs from header')
+
+  prepareTest("")
+  s = '<h1><i><b>test</b></i> test</h1>'
+  editor.setHTML(s)
+  s2 = editor.getHTML()
+  test(s2 == '<h1><i>test</i> test<br></h1>', 'strip bs in is from header')
+
+  //
+  prepareTest("")
+  s = '<h1><div>test</div></h1>'
+  editor.setHTML(s)
+  s2 = editor.getHTML()
+  test(s2 == '<h1>test<br></h1>', 'strip div from header')
+
+  prepareTest("")
+  s = '<h1>test<div>x</div>test</h1>'
+  editor.setHTML(s)
+  s2 = editor.getHTML()
+  test(s2 == '<h1>testxtest<br></h1>', 'strip div from header')
+
+  prepareTest("")
+  s = '<h2>test<div></div><div></div><div></div><div></div></h2>'
+  editor.setHTML(s)
+  s2 = editor.getHTML()
+  test(s2 == '<h2>test<br></h2>', 'strip many empty div from header')
+
+  prepareTest("")
+  s = '<h2><div><div><div>test</div></div></div></h2>'
+  editor.setHTML(s)
+  s2 = editor.getHTML()
+  test(s2 == '<h2>test<br></h2>', 'strip nested div from header')
 
 }
 

--- a/examples/test.js
+++ b/examples/test.js
@@ -72,7 +72,7 @@ var initEditors = function(){
     });
 
     testSetup()
-    
+
     // quickTest()
     // NATE: unfortunately this test makes the later test "does not filter math elements" fail.  I don't yet understand why
     // but it has to do with how the cursor is positioned in the editor.
@@ -544,7 +544,6 @@ moreCleanerTests = function(){
   s2 = editor.getHTML()
   test(s2 == '<h1><i>test</i> test<br></h1>', 'strip bs in is from header')
 
-  //
   prepareTest("")
   s = '<h1><div>test</div></h1>'
   editor.setHTML(s)
@@ -573,10 +572,7 @@ moreCleanerTests = function(){
   s = '<div><div><div>test</div></div></div>'
   editor.setHTML(s)
   s2 = editor.getHTML()
-  console.log('?????????XXXXX',s2)
   test(s2 == '<div>test<br></div>', 'strip nested div')
-
-
 }
 
 testInsertHTML = function(){

--- a/examples/test.js
+++ b/examples/test.js
@@ -72,6 +72,7 @@ var initEditors = function(){
     });
 
     testSetup()
+    
     // quickTest()
     // NATE: unfortunately this test makes the later test "does not filter math elements" fail.  I don't yet understand why
     // but it has to do with how the cursor is positioned in the editor.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire-rte-rewrite",
-  "version": "1.6.33",
+  "version": "1.6.34",
   "description": "Squire is an HTML5 rich text editor, which provides powerful cross-browser normalisation, whilst being supremely lightweight and flexible.",
   "main": "build/squire.js",
   "scripts": {

--- a/source/Clean.js
+++ b/source/Clean.js
@@ -166,9 +166,6 @@ var replaceStyles = function ( node, parent ) {
 //NATE: I like the stylesRewriters, we should have sane defaults for all the elements as a first pass, and then
 // any additional complicated filtering can be done by registering filters with squire that will be executed during
 // insertHTML
-
-
-
 var stylesRewriters = {
     SPAN: replaceStyles,
     CITE: replaceStyles,
@@ -293,7 +290,7 @@ var doNotCleanNode = function(node){
 */
 
 
-// name them whatever you want (human readable)
+// name the keys whatever you want (human readable)
 var nodeGroupToBlackList = {
     "header": {
         nodesRegEx: /^(?:H1|H2|H3)$/,
@@ -305,21 +302,26 @@ var nodeGroupToBlackList = {
     }
 }
 
-// nesetdNodeTracker makes node regex to boolean indicating whether it's been seen yet
-var shouldUnwrapNode = function(nodeName, nestedNodeTracker) {
+// nesetdNodeTracker maps node group (see above to boolean indicating whether it's been seen yet
+var shouldUnwrapNode = function(nestedNodeTracker, nodeName ) {
     var blackListRegex;
+    // check nodesGroups we're already "inside of"
     for(var nodeGroup in nestedNodeTracker){
         blackListRegex = nodeGroupToBlackList[nodeGroup].blackListRegEx;
-        return blackListRegex.test(nodeName)
+        // If our element is blacklisted, unwrap it
+        if (blackListRegex.test(nodeName)){
+            return true
+        }
     }
     return false
-
 };
 
 var getNewNestedNodeHash = function(nestedNodeTracker, nodeName){
     var nodesRegEx;
+    // check all nodegroups with blacklists
     for(var nodeGroup in nodeGroupToBlackList){
         nodesRegEx = nodeGroupToBlackList[nodeGroup].nodesRegEx;
+        // If the nodegroup isn't blacklistsed yet, and our node is in the group, add the nodegroup to the blacklist
         if(!nestedNodeTracker[nodeGroup] && nodesRegEx.test(nodeName)){
             var newNestedNodeTracker = {};
             newNestedNodeTracker[nodeGroup] = true
@@ -328,7 +330,6 @@ var getNewNestedNodeHash = function(nestedNodeTracker, nodeName){
     } 
     return nestedNodeTracker
 }
- 
 
 var cleanTree = function cleanTree ( node, preserveWS, nestedNodeTracker ) {
     if(!nestedNodeTracker){
@@ -369,7 +370,7 @@ var cleanTree = function cleanTree ( node, preserveWS, nestedNodeTracker ) {
                 l -= 1;
                 continue;
             }  // unwrap elements not whitelisted and blacklisted nested elements
-             else if(shouldUnwrapNode(nodeName, nestedNodeTracker)|| (!allowedBlock.test( nodeName ) && !isInline( child ) )){
+             else if(shouldUnwrapNode(nestedNodeTracker,nodeName)|| (!allowedBlock.test( nodeName ) && !isInline( child ) )){
               i -= 1;
               l += childLength - 1;
               node.replaceChild( empty( child ), child );


### PR DESCRIPTION
Ensure headers have no unwanted tags nested inside them - `/^(?:B|DIV|H1|H2|H3|UL|OL|LI|TABLE)$/;`

This cleans up some of these cases: https://github.com/natejenkins/socialApp/issues/3702, and generally gets one step closer to the cleaner forcing conformity to the spec. Shows the general format we can use in the cleaner for conditionally unwrapping elements depending on how they are nested. Nested `divs` more generally is next... 
