### PR TITLE
Stop selection from spilling over lines accidentally

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -547,7 +547,7 @@ proto.setSelectionToNode = function (node, startOffset){
 proto.getSelection = function () {
     var sel = getWindowSelection( this );
     var root = this._root;
-    var selection, startContainer, endContainer;
+    var selection, startContainer, endContainer, walker, previousNode;
     if ( sel && sel.rangeCount ) {
         selection  = sel.getRangeAt( 0 ).cloneRange();
         startContainer = selection.startContainer;
@@ -560,8 +560,17 @@ proto.getSelection = function () {
             selection.setEndBefore( endContainer );
         }
 
-        if (!startContainer.isSameNode(endContainer) && selection.endOffset === 0) {
-            selection.setEndBefore(endContainer)
+        if ( startContainer && endContainer &&
+             !startContainer.isSameNode(endContainer) &&
+             selection.endOffset === 0
+        ) {
+            walker = new TreeWalker(selection.commonAncestorContainer, SHOW_TEXT);
+
+            walker.currentNode = selection.endContainer;
+            previousNode = walker.previousNode()
+
+            // We know it's a text node because of the walker filter
+            selection.setEnd(previousNode, previousNode.data.length)
         }
     }
     if ( selection &&

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -559,6 +559,10 @@ proto.getSelection = function () {
         if ( endContainer && isLeaf( endContainer, root ) ) {
             selection.setEndBefore( endContainer );
         }
+
+        if (!startContainer.isSameNode(endContainer) && selection.endOffset === 0) {
+            selection.setEndBefore(endContainer)
+        }
     }
     if ( selection &&
             isOrContains( root, selection.commonAncestorContainer ) ) {

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -569,8 +569,10 @@ proto.getSelection = function () {
             walker.currentNode = selection.endContainer;
             previousNode = walker.previousNode()
 
-            // We know it's a text node because of the walker filter
-            selection.setEnd(previousNode, previousNode.data.length)
+            if (previousNode) {
+                // We know it's a text node because of the walker filter
+                selection.setEnd(previousNode, previousNode.data.length)
+            }
         }
     }
     if ( selection &&

--- a/source/TreeWalker.js
+++ b/source/TreeWalker.js
@@ -29,7 +29,7 @@ var typeToBitArray = {
 function TreeWalker ( root, nodeType, filter ) {
     this.root = this.currentNode = root;
     this.nodeType = nodeType;
-    this.filter = filter;
+    this.filter = filter || (function () { return true });
 }
 
 // There is a javascript TreeWalker already that I don't want to write over


### PR DESCRIPTION
This code might have some unforseen consequences, but hoping it should remove a class of bug (accidental formatting changes) when the user selects a whole block element.

As it stands, https://github.com/natejenkins/socialApp/issues/3961 can't be fixed without this or a replacement solution.