### PR TITLE
Fix firefox spacing in headers wonk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire-rte-rewrite",
-  "version": "1.6.32",
+  "version": "1.6.33",
   "description": "Squire is an HTML5 rich text editor, which provides powerful cross-browser normalisation, whilst being supremely lightweight and flexible.",
   "main": "build/squire.js",
   "scripts": {

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1691,7 +1691,7 @@ proto.getHTML = function ( options ) {
         ensureBrAtEndOfAllLines(root)
     }
     else if(options["stripAllBrs"]){
-        ensureBrAtEndOfAllTags(root, ['div', 'li'])
+        ensureBrAtEndOfAllTags(root, ['div', 'li', 'h1', 'h2', 'h3'])
     }
     return html;
 };


### PR DESCRIPTION
Fixes https://github.com/natejenkins/socialApp/issues/3971
Firefox wants brs at the end of lines - it puts them there automatically (unlike chrome). Leaving them out of headers causes the spaces at the end to get lost.