### PR TITLE
allow creation of empty text node when range points past end of line 

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -104,7 +104,7 @@ function Squire ( root, config ) {
         }
         else{
           console.info("NOT TEXT NODE")
-          previous = findPreviousTextOrNotEditable(root, child)
+          previous = child && findPreviousTextOrNotEditable(root, child)
           if(notEditable(previous, root)){
             console.info("prev not edit")
             // TODO: nate: could possibly just insert the char here


### PR DESCRIPTION
Fixes https://github.com/natejenkins/squire/issues/44

Easy to reproduce bug - hit space at the end of a line when inside an inline style element (bold, italics, code). The range localization (child at current offset) goes past the end of the line, making child `undefined` - in this case, we should create a text node instead of throwing an error.

The only reason we never see this for text in regular divs is that divs end with brs, so brs become the focused node (instead of `undefined`).