### PR TITLE
Expose findNextTextOrNotEditable

### DIFF
--- a/source/KeyHandlers.js
+++ b/source/KeyHandlers.js
@@ -424,15 +424,6 @@ var findPreviousBRTag = function(root, node){
     return w.previousNode()
 }
 
-var findNextTextOrNotEditable = function(root, node){
-    var w = new TreeWalker(root, NodeFilter.SHOW_ALL, function(node, root){
-        return ( isText(node) || notEditable(node, root) )
-    } );
-    w.currentNode = node;
-    //NATE: TODO: call this with root
-    return w.nextNONode(notEditable)
-}
-
 var findPreviousTextOrNotEditable = function(root, node){
     var w = new TreeWalker(root, NodeFilter.SHOW_ALL, function(node, root){
         return ( isText(node) || notEditable(node, root) )

--- a/source/Node.js
+++ b/source/Node.js
@@ -165,6 +165,16 @@ function getNextBlock ( node, root ) {
     return node !== root ? node : null;
 }
 
+function findNextTextOrNotEditable (root, node){
+    var w = new TreeWalker(root, NodeFilter.SHOW_ALL, function(node, root){
+        return ( isText(node) || notEditable(node, root) )
+    } );
+    w.currentNode = node;
+    //NATE: TODO: call this with root
+    return w.nextNONode(notEditable)
+}
+
+
 function areAlike ( node, node2, root ) {
     return !isLeaf( node, root ) && (
         node.nodeType === node2.nodeType &&
@@ -640,3 +650,4 @@ Squire.Node.isBlock = isBlock
 Squire.Node.isZWS = isZWS
 Squire.Node.empty = empty
 Squire.Node.isLeaf = isLeaf
+Squire.Node.findNextTextOrNotEditable = findNextTextOrNotEditable


### PR DESCRIPTION
What I would have liked to do is move this functions to a `lib` directory here or something, but that's extra effort because right now Squire doesn't use a standard module system internally, and we wouldn't be able to `import`/`require` them here.

Where we expose it is up to @natejenkins but it made since to expose it on `Node` rather than in the `KeyHandlers` file to me.