### PR TITLE
Alt font/background color method

### DIFF
--- a/examples/squire-ui.css
+++ b/examples/squire-ui.css
@@ -12,10 +12,27 @@ h1 {
 iframe {
   border: 1px solid #888;
 }
-span {
+span.not-editable {
   cursor: pointer;
   text-decoration: underline;
 }
+
+span.au-background-yellow{
+  background-color: yellow;
+}
+
+span.au-background-red{
+  background-color: red;
+}
+
+span.au-font-red{
+  color: red;
+}
+
+span.au-font-yellow{
+  color: yellow;
+}
+
 p {
   margin: 5px 0;
 }

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1992,58 +1992,46 @@ proto.underline = command( 'changeFormat', { tag: 'U' } );
 proto.strikethrough = command( 'changeFormat', { tag: 'S' } );
 
 
-proto.colorizeBackground = function ( backgroundColorClass ) {
-    // TODO: enforce only supported colors?
-    this.changeFormat({
-        tag: 'SPAN',
-        attributes: {
-            'class': backgroundColorClass,
-        }
-    })
-    return this.focus();
-};
+
+proto.removeBackgroundColor =  command( 'changeFormat', null,  { tag: 'SPAN', attributes:{  'data-background': 'true'} } );
 
 proto.changeBackgroundColor = function ( backgroundColorClass ) {
-    if (!color) return
+    if (!backgroundColorClass) return
     this.changeFormat(
         { tag: 'SPAN',
         attributes: 
         {
             'class': backgroundColorClass,
+            'data-background': 'true'
         }}, {
-        tag: 'SPAN'
-    })
-    return this.focus();
-};
-
-proto.colorizeFont = function ( colorClass ) {
-    // TODO: enforce only supported colors?
-    this.changeFormat({
         tag: 'SPAN',
-        attributes: {
-            'class': colorClass,
+        attributes:{
+            'data-background': 'true'
         }
     })
     return this.focus();
 };
+
 
 proto.changeFontColor = function ( colorClass ) {
     if (!colorClass) return
     this.changeFormat(
         { tag: 'SPAN',
-        attributes: 
-        {
+        attributes: {
             'class': colorClass,
-        }}, {
-        tag: 'SPAN'
-    })
+            'data-font-color': 'true'}
+        }, {
+        tag: 'SPAN',
+        attributes: {
+            'data-font-color': 'true'}
+        }
+    )
     return this.focus();
 };
 
 
-proto.removeFontColor =  command( 'changeFormat', null,  { tag: 'SPAN' } );
+proto.removeFontColor =  command( 'changeFormat', null,  { tag: 'SPAN', attributes:{  'data-font-color': 'true'} } );
 
-proto.removeBackgroundColor =  command( 'changeFormat', null,  { tag: 'SPAN' } );
 
 proto.subscript = command( 'changeFormat', { tag: 'SUB' }, { tag: 'SUP' } );
 proto.superscript = command( 'changeFormat', { tag: 'SUP' }, { tag: 'SUB' } );

--- a/source/Node.js
+++ b/source/Node.js
@@ -225,10 +225,11 @@ function getPath ( node, root, options ) {
     var path = '';
     var id, className, classNames, dir;
     if ( node && node !== root ) {
-        // include classes for background & font -color: TODO: double check no weird sideeffects with paths for non-editable elements..
-        if (node.nodeName== 'SPAN'){
-            options['include_attributes'] = true;
-        }
+
+        // Leaving commented for now: include classes for background & font -color: TODO: double check no weird sideeffects with paths for non-editable elements..
+        // if (node.nodeName== 'SPAN'){
+        //     options['include_attributes'] = true;
+        // }
 
         path = getPath( node.parentNode, root );
         if ( node.nodeType === ELEMENT_NODE ) {


### PR DESCRIPTION
Much better/ simpler - only requires 2 methods for each (font & background). Uses "change" functionality of changeFormat more liberally.

Including the new css only for local testing purposes (does not compile/ship)