### PR TITLE
set new calculated range after merge inlines in getHTML

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1682,7 +1682,8 @@ proto.getHTML = function ( options ) {
         }
     }
     if ( range ) {
-        this._getRangeAndRemoveBookmark( range );
+        range = this._getRangeAndRemoveBookmark( range );
+        this.setSelection(range);
     }
     // TODO: NATE: might need to extend this to li elements.  Squire uses BR tags
     // internally to correct some browser behavior but we don't necessarily wants


### PR DESCRIPTION
As is, `_mergeInLines` recalculates a new range for after the elements are merged, but this new range is never actually set; because of side-effects of the elements-merging effecting the range anyway, this oversight was hard to notice, but it does introduce bugs (i.e., range extending to matching elements after `getHTML({withBookMark:1})` is called. This let to side effects / sub-optimal patches trickling into the authorea side of things.

Fixing simply requires setting the new range (called "fakeRange" in mergeInlines") in `getHTML`.