### PR TITLE
monkey patch fix for deleting with non-editable node 

### DIFF
--- a/source/KeyHandlers.js
+++ b/source/KeyHandlers.js
@@ -655,7 +655,7 @@ Squire.prototype.backspace = function(self, event, range){
        
             // This if-condition is a monkey patch to get around improper range calculation; it doesn't fix the core problem (start offset is off), but it side-steps it in this one case in a guarunteed regression-free way. If the range calculation is ever fixed, it can be removed)
             if (so >= sc.childNodes.length && notEditable(sc.lastChild)  ){
-                detach(sc.childNodes[sc.childNodes.length -1]);
+                detach(sc.lastChild);
             } else {
                 var child = sc.childNodes[so]
                 pn = findPreviousTextOrNotEditable(block, child)

--- a/source/KeyHandlers.js
+++ b/source/KeyHandlers.js
@@ -657,33 +657,28 @@ Squire.prototype.backspace = function(self, event, range){
             if (so >= sc.childNodes.length && notEditable(sc.lastChild)  ){
                 detach(sc.childNodes[sc.childNodes.length -1]);
             } else {
-
-                if (so >= sc.childNodes.length && notEditable(sc.lastChild)  ){
-                    detach(sc.childNodes[sc.childNodes.length -1]);
-                } else {
-                    var child = sc.childNodes[so]
-                    pn = findPreviousTextOrNotEditable(block, child)
-                    if(pn){
-                        if(pn.nodeType === TEXT_NODE){
-                            if(pn.length>0){
-                                pn.deleteData(pn.length - 1, 1)
-                                pOffset = pn.length
-                                range.setStart(pn, pOffset)
-                                range.setEnd(pn, pOffset)
-                                self.setSelectionToNode(pn, pOffset)
-                            }
-                            else{
-                                detach(pn)
-                            }
-
+                var child = sc.childNodes[so]
+                pn = findPreviousTextOrNotEditable(block, child)
+                if(pn){
+                    if(pn.nodeType === TEXT_NODE){
+                        if(pn.length>0){
+                            pn.deleteData(pn.length - 1, 1)
+                            pOffset = pn.length
+                            range.setStart(pn, pOffset)
+                            range.setEnd(pn, pOffset)
+                            self.setSelectionToNode(pn, pOffset)
                         }
-                        else if(notEditable(pn, root)){
-                            detach(pn);
+                        else{
+                            detach(pn)
                         }
+
+                     }
+                    else if(notEditable(pn, root)){
+                        detach(pn);
                     }
                 }
             }
-
+            
             //Nate: Todo: Currently cleaning from this node results in the range not getting moved down the tree, not good
             rootNodeOfClean = sc
         }

--- a/source/KeyHandlers.js
+++ b/source/KeyHandlers.js
@@ -652,24 +652,35 @@ Squire.prototype.backspace = function(self, event, range){
             }
         }
         else {
-            var child = sc.childNodes[so]
-            pn = findPreviousTextOrNotEditable(block, child)
-            if(pn){
-                if(pn.nodeType === TEXT_NODE){
-                    if(pn.length>0){
-                        pn.deleteData(pn.length - 1, 1)
-                        pOffset = pn.length
-                        range.setStart(pn, pOffset)
-                        range.setEnd(pn, pOffset)
-                        self.setSelectionToNode(pn, pOffset)
-                    }
-                    else{
-                        detach(pn)
-                    }
+       
+            // This if-condition is a monkey patch to get around improper range calculation; it doesn't fix the core problem (start offset is off), but it side-steps it in this one case in a guarunteed regression-free way. If the range calculation is ever fixed, it can be removed)
+            if (so >= sc.childNodes.length && notEditable(sc.lastChild)  ){
+                detach(sc.childNodes[sc.childNodes.length -1]);
+            } else {
 
-                }
-                else if(notEditable(pn, root)){
-                    detach(pn);
+                if (so >= sc.childNodes.length && notEditable(sc.lastChild)  ){
+                    detach(sc.childNodes[sc.childNodes.length -1]);
+                } else {
+                    var child = sc.childNodes[so]
+                    pn = findPreviousTextOrNotEditable(block, child)
+                    if(pn){
+                        if(pn.nodeType === TEXT_NODE){
+                            if(pn.length>0){
+                                pn.deleteData(pn.length - 1, 1)
+                                pOffset = pn.length
+                                range.setStart(pn, pOffset)
+                                range.setEnd(pn, pOffset)
+                                self.setSelectionToNode(pn, pOffset)
+                            }
+                            else{
+                                detach(pn)
+                            }
+
+                        }
+                        else if(notEditable(pn, root)){
+                            detach(pn);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
```js
 if (so >= sc.childNodes.length && notEditable(sc.lastChild)  ){
                detach(sc.lastChild);
            }
```
is the only new code, rest is indenting.

This is a monkey patch fix for deleting a non-editable node inside a bold/italics tag at the end of a line. The issue is with range calculation; this does not fix the core issue. However, it intercepts this particular bug and fixes it in a guaranteed regression-free way (i.e., without this, it would simply through an error). It can be removed when/if the range calculation is fixed, but for now it's an easy way to remove some friction. 