### PR TITLE
Fix non edit cursor bug

### DIFF
--- a/source/Range.js
+++ b/source/Range.js
@@ -437,7 +437,6 @@ var moveRangeBoundariesUpTree = function ( range, common ) {
 };
 
 var moveNodeOutOfNotEditable = function( node, nodeOffset ){
-
     var startContainer = node
     var moveRight = false
     var nextSibling
@@ -458,7 +457,7 @@ var moveNodeOutOfNotEditable = function( node, nodeOffset ){
     else{
       currentParent = startContainer.parentNode
       newParent = currentParent
-    } 
+    }
     while(notEditable(newParent)){
         currentParent = newParent
         if(moveRight){
@@ -469,7 +468,7 @@ var moveNodeOutOfNotEditable = function( node, nodeOffset ){
         newParent = currentParent.parentNode
     }
     if(newParent !== currentParent){
-        offset = indexOf.call( newParent.childNodes, currentParent ) 
+        offset = indexOf.call( newParent.childNodes, currentParent )
         return([newParent, offset])
     }
     else{

--- a/source/Range.js
+++ b/source/Range.js
@@ -437,6 +437,7 @@ var moveRangeBoundariesUpTree = function ( range, common ) {
 };
 
 var moveNodeOutOfNotEditable = function( node, nodeOffset ){
+
     var startContainer = node
     var moveRight = false
     var nextSibling
@@ -457,19 +458,18 @@ var moveNodeOutOfNotEditable = function( node, nodeOffset ){
     else{
       currentParent = startContainer.parentNode
       newParent = currentParent
-    }
+    } 
     while(notEditable(newParent)){
         currentParent = newParent
         if(moveRight){
-            if(nextSibling = currentParent.nextSibling){
+            if(nextSibling = new TreeWalker(currentParent, NodeFilter.SHOW_ALL,function(){return true}).nextSNode()){
                 currentParent = nextSibling
             }
         }
         newParent = currentParent.parentNode
-        startOffset = indexOf.call( newParent.childNodes, currentParent );
     }
     if(newParent !== currentParent){
-        offset = indexOf.call( newParent.childNodes, currentParent )
+        offset = indexOf.call( newParent.childNodes, currentParent ) 
         return([newParent, offset])
     }
     else{

--- a/source/TreeWalker.js
+++ b/source/TreeWalker.js
@@ -110,6 +110,30 @@ TreeWalker.prototype.nextNONode = function (breakoutFunction) {
     }
 };
 
+TreeWalker.prototype.nextSNode = function (){
+    var current = this.currentNode,
+    root = this.root,
+    nodeType = this.nodeType,
+    filter = this.filter,
+    node, sib, parent;
+    while ( true ) {
+        if(sib = current.nextSibling){
+            this.currentNode = sib 
+            return sib
+        } else {
+            parent = current.parentNode
+            sib = parent.nextSibling
+            if (!sib){
+                this.currentNode = null
+                return null
+            } else {
+                this.currentNode = sib 
+                return sib.firstChild ? sid.firstChild : sib
+            }
+        }
+    }
+}
+
 // NATE: the breakoutFunction takes (node, root)
 TreeWalker.prototype.previousNode = function (breakoutFunction) {
     var current = this.currentNode,

--- a/source/TreeWalker.js
+++ b/source/TreeWalker.js
@@ -110,6 +110,7 @@ TreeWalker.prototype.nextNONode = function (breakoutFunction) {
     }
 };
 
+// NOTE: haven't included a fliter/ breakut function yet
 TreeWalker.prototype.nextSNode = function (){
     var current = this.currentNode,
     root = this.root,


### PR DESCRIPTION
Big happens when cursor is inside a non-editable element inside a macro (bold italics). This ought to fix by properly calculating the next element via a new treewalker method